### PR TITLE
changing the network-version-match parameter

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -41,7 +41,7 @@ p2p-peer-address = cheetah.jungle3.bptn.eosamsterdam.net:9876
 p2p-peer-address = testnet.eosindia.io:9876
 p2p-peer-address = 35.189.107.125:9876
 p2p-peer-address = bpseoul.eosnodeone.io:9876
-
+p2p-peer-address = n2.eosargentina.io:9876
 #p2p-peer-address = 218.18.171.81:9876
 #p2p-peer-address = 34.206.54.155:9876
 
@@ -62,7 +62,7 @@ allowed-connection = any
 log-level-net-plugin = info
 max-clients = 25
 connection-cleanup-period = 30
-network-version-match = 0
+network-version-match = 1
 sync-fetch-span = 1000
 enable-stale-production = false
 required-participation = 33


### PR DESCRIPTION
Until the protocol is stable we should force all the nodes of the testnet to use the same version of the network protocol, later when there is backward compatibility we can change it