### PR TITLE
[FIX] Change 777 for executables to +x mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ git submodule update --init --recursive
   ```   
 - add execution rights  
   ```
-  chmod -R 777 ./*.sh   
-  chmod -R 777 ./Wallet/*.sh 
+  chmod +x ./*.sh   
+  chmod +x ./Wallet/*.sh 
   ```  
 
 - If you use different data-dir folders -> edit all paths in files cleos.sh, start.sh, stop.sh, config.ini, Wallet/start_wallet.sh, Wallet/stop_wallet.sh:


### PR DESCRIPTION
777 permissions are redundant, so use +x (execute) mode instead.